### PR TITLE
carga a DM selectiva por supervisor/encuestador-ticket 320

### DIFF
--- a/src/server/procedures-ipcba.js
+++ b/src/server/procedures-ipcba.js
@@ -486,13 +486,13 @@ function dm2CrearQueries(parameters, context){
             GROUP BY periodo, informante, visita, nombreinformante, direccion, panel, tarea, maxperiodoinformado, observaciones, observaciones_campo
         `;
     var sqlHdR=`
-        SELECT encuestador, per.nombre as nombreencuestador, per.apellido as apellidoencuestador,
+        SELECT coalesce(supervisor, encuestador) as encuestador, per.nombre as nombreencuestador, per.apellido as apellidoencuestador,
                 (select ipad from instalaciones where id_instalacion = rt.id_instalacion ) as dispositivo,
                 current_date as fecha_carga,
                 rt.panel, rt.tarea, rt.periodo,
                 rt.modalidad,
                 ${json(sqlInformantes,'direccion, informante')} as informantes
-            FROM reltar rt INNER JOIN periodos p USING (periodo) inner join personal per on encuestador = per.persona
+            FROM reltar rt INNER JOIN periodos p USING (periodo) inner join personal per on coalesce(supervisor, encuestador) = per.persona
             WHERE rt.periodo=$1
                 AND rt.panel=$2
                 AND rt.tarea=$3
@@ -1098,7 +1098,7 @@ ProceduresIpcba = [
                         from reltar r
                         left join instalaciones i using (id_instalacion)
                         left join personal p on p.persona = i.encuestador
-                        where r.encuestador = $1 and
+                        where coalesce(r.supervisor, r.encuestador) = $1 and
                               vencimiento_sincronizacion2 is not null and
                               vencimiento_sincronizacion2 > current_timestamp
                         order by vencimiento_sincronizacion2 desc


### PR DESCRIPTION
Al momento de preparar la carga del DM poder asignarla a una persona que se desempeñe como supervisor en

https://ipc.estadisticaciudad.gob.ar/ipcba/menu#i=gabinete,supervisiones,periodos_reltar

poniendo su código en la columna supervisor, sin cambiar el valor de la columna encuestador 
(excepto que se trate de un reemplazo).

Evita cambiar la columna encuestador a un código de supervisor para luego restaurarla a su valor original para que quede reflejado 
quién hizo el relevamiento primero (antes de ser supervisado).

Cabe aclarar que los registros en la descarga (todos y cada uno de ellos, formularios, precios, atributos, comentarios, etc, etc) 
quedarán a nombre de la última persona que descargó el dispositivo, aunque esta persona sea un supervisor 
que ha cambiado un sólo precio